### PR TITLE
adding feedback google document link

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -5,6 +5,7 @@ La retroalimentación que usted pueda aportar, especialmente en su rol de
 administrador de repositorio, es importante para nosotros. Puede hacernos llegar sus 
 comentarios mediante los siguientes canales de comunicación:
 
+* agregando un comentario a nuestro documento de comentarios v4 (no se necesita cuenta) en: https://docs.google.com/document/d/1aFWrkBO_f_GTWWTAfco4uoUphEbtOOdJVD_2ohYw7Ek/edit
 * Cree un reporte (issue) en el repositorio GitHub de nuestras directrices (requiere una cuenta en GitHub): https://github.com/openaire/guidelines-literature-repositories/issues.
 * Incluya sus comentarios en las páginas de las directrices (requiere una cuenta en https://web.hypothes.is): simplemente marque el texto y podrá agregar sus comentarios.
 * Envíe un correo electrónico a: guidelines@openaire.eu


### PR DESCRIPTION
Adding the feedback google document link for 'institutional and thematic repository managers' v4 .